### PR TITLE
[feat #19] .layout-default의 width 100%로 변경

### DIFF
--- a/src/components/layout/LayoutDefault.vue
+++ b/src/components/layout/LayoutDefault.vue
@@ -38,7 +38,7 @@
   .layout-default {
     display: flex;
     height: 100vh;
-    width: 100vw;
+    width: 100%;
     background-color: #f9f9f9;
     overflow: hidden;
   }


### PR DESCRIPTION
Closes #19 

## 🔥 작업 내용  
- [ ] .layout-default의 width 100%로 변경
- [ ] 가로 스크롤이 생기지 않게 함

## ✅ 체크 리스트  
- [ ] 다른 페이지에 영향이 미치는지 확인

## ✨ 관련 이슈
- #19
